### PR TITLE
Add leaf surface area calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ To execute the example scripts:
    - `sphereTest` reconstructs a hemisphere from a small sample point cloud.
    - `main` performs a reconstruction of a sample plant leaf.
 3. Output figures and data will be written to a new folder under `saves/`.
+4. The surface area of the reconstructed mesh can be computed using
+   `meshSurfaceArea` on the returned structure. Both example scripts now
+   print the area estimated from marching cubes and marching tetrahedra.
 
 ### Reading PLY files
 Custom 3D point clouds stored in ASCII PLY format can be imported using the

--- a/main.m
+++ b/main.m
@@ -70,9 +70,13 @@ condition = OBJ.fit(rbf, polydegree, rho, regFn);
 % For gridded sample & marching cubes:
 [X, Y, Z, INTERP] = OBJ.gridSample(Ngrid, alpha);
 S_cube = isosurface(X,Y,Z,INTERP);
+area_cube = meshSurfaceArea(S_cube);
+fprintf('Surface area from marching cubes: %.5g\n', area_cube);
 
 % For tetrahedral mesh of alphaShape & marching tetra:
 S_tet = aShapeSample(OBJ, alpha, Hmax);
+area_tet = meshSurfaceArea(S_tet);
+fprintf('Surface area from marching tetrahedra: %.5g\n', area_tet);
 
 
 %% Save

--- a/meshSurfaceArea.m
+++ b/meshSurfaceArea.m
@@ -1,0 +1,21 @@
+function area = meshSurfaceArea(S)
+%MESHSURFACEAREA Compute surface area of a triangular mesh.
+%   AREA = MESHSURFACEAREA(S) returns the total area of the mesh described
+%   by the structure S, which must contain fields 'faces' and 'vertices'
+%   as produced by MATLAB functions such as `isosurface` or the provided
+%   `aShapeSample` routine.
+%
+%   Example:
+%       S = isosurface(X,Y,Z,V);
+%       area = meshSurfaceArea(S);
+%
+%   See also isosurface, alphaShape
+
+tri1 = S.vertices(S.faces(:,1),:);
+tri2 = S.vertices(S.faces(:,2),:);
+tri3 = S.vertices(S.faces(:,3),:);
+
+crossProd = cross(tri2 - tri1, tri3 - tri1, 2);
+triArea = 0.5 * vecnorm(crossProd, 2, 2);
+area = sum(triArea);
+end

--- a/sphereTest.m
+++ b/sphereTest.m
@@ -51,9 +51,13 @@ condition = OBJ.fit(rbf, polydegree, rho, regFn);
 % For gridded sample & marching cubes:
 [X, Y, Z, INTERP] = OBJ.gridSample(Ngrid, alpha);
 S_cube = isosurface(X,Y,Z,INTERP);
+area_cube = meshSurfaceArea(S_cube);
+fprintf('Surface area from marching cubes: %.5g\n', area_cube);
 
 % For tetrahedral mesh of alphaShape & marching tetra:
 S_tet = aShapeSample(OBJ, alpha, Hmax);
+area_tet = meshSurfaceArea(S_tet);
+fprintf('Surface area from marching tetrahedra: %.5g\n', area_tet);
 
 
 %% Save


### PR DESCRIPTION
## Summary
- add `meshSurfaceArea` helper for computing triangle mesh area
- print surface area for the cube and tetrahedral meshes in both example scripts
- document the new post-processing step in the README

## Testing
- `apt-get update`
- `apt-get install -y octave` *(fails: ca-certificates-java error)*

------
https://chatgpt.com/codex/tasks/task_e_688b0e4da7488327b27a66ac3f126fec